### PR TITLE
[WIP] - Update 'from' imports

### DIFF
--- a/__testfixtures__/imports/bindingFrom.output.js
+++ b/__testfixtures__/imports/bindingFrom.output.js
@@ -1,1 +1,2 @@
-import {hideAddressBar as hab} from 'device';
+import device from 'device';
+var { hab } = device;

--- a/__testfixtures__/imports/bindingFrom.output.js
+++ b/__testfixtures__/imports/bindingFrom.output.js
@@ -1,2 +1,5 @@
 import device from 'device';
-var { hab } = device;
+
+const {
+  hideAddressBar: hab
+} = device;

--- a/__testfixtures__/imports/bindingFromCollision.js
+++ b/__testfixtures__/imports/bindingFromCollision.js
@@ -1,0 +1,3 @@
+from device import hideAddressBar as hab;
+
+hideAddressBar();

--- a/__testfixtures__/imports/breadcrumb.input.js
+++ b/__testfixtures__/imports/breadcrumb.input.js
@@ -9,3 +9,5 @@ exports.something = layout.BackingExtension;
 var uiKeyboardTypes = {};
 import ...ui.keyboardTypes;
 console.log(ui.keyboardTypes);
+
+const boom = new lib.PubSub();

--- a/__testfixtures__/imports/breadcrumb.output.js
+++ b/__testfixtures__/imports/breadcrumb.output.js
@@ -9,3 +9,5 @@ exports.something = BackingExtension;
 var uiKeyboardTypes = {};
 import keyboardTypes from '../../ui/keyboardTypes';
 console.log(keyboardTypes);
+
+const boom = new PubSub();

--- a/__tests__/imports.js
+++ b/__tests__/imports.js
@@ -31,6 +31,10 @@ describe('Imports Transform', () => {
     defineTestWhichThrows('imports/simpleCollision');
   });
 
+  describe('when from import collides with another variable', () => {
+    defineTestWhichThrows('imports/bindingFromCollision');
+  });
+
   defineTest('imports/binding');
   defineTest('imports/member');
   defineTest('imports/multipleInline');

--- a/mods/lib/importPatterns.js
+++ b/mods/lib/importPatterns.js
@@ -176,11 +176,29 @@ const importPatterns = {
       const dotPath = _.get(match, 'captures.dotPath[0]');
       const modulePath = getModulePath(module, dotPath);
 
+      detectNamingCollision(j, item, module);
       detectNamingCollision(j, item, moduleName);
+      detectNamingCollision(j, item, alias);
 
       j(item).replaceWith(
-        buildAliasImport(j, moduleName, modulePath, alias)
-      )
+        buildDefaultImport(j, module, modulePath)
+      );
+
+      j(item).closest(j.Statement).insertAfter(
+        j.variableDeclaration(
+          'const',
+          [j.variableDeclarator(
+            j.objectPattern([
+              j.property(
+                'init',
+                j.identifier(moduleName),
+                j.identifier(alias)
+              )
+            ]),
+            j.identifier(module)
+          )]
+        )
+      );
     }
   }
 };


### PR DESCRIPTION
Because we want to bundle all exported variables in the default export we need to consider the same for imports.

Right now, this bit of jsio syntax:

``` js
from device import hideAddressBar as hab;
```

compiles to this:

``` js
import { hab } from 'device';
```

which quite obviously won't work because hab is bound to  the default export.

There's no compatible transform for this really, so instead we need to import the module and then destructure the `from`:

``` js
import device from 'device';
var { hab } = device;
```

not super pretty but the only way I can see rn. cc @yofreke 
