### PR TITLE
Alternate errors formatting

### DIFF
--- a/mods/imports.js
+++ b/mods/imports.js
@@ -12,32 +12,53 @@ var replaceFn = function (raw, p1, p2, p3) {
   return raw;
 }
 
-const transformImport = (j, item) => {
+const transformImport = (j, filePath, item) => {
   if (
     !item.parent ||
     !item.parent.parent ||
     item.parent.parent.name !== 'program'
   ) {
-    error(item.value.arguments[0], 'Imports must be top level');
+    error.error({
+      node: item.value.arguments[0],
+      message: 'Imports must be top level',
+      filePath: filePath
+    });
   }
 
   if (item.value.arguments.length !== 1) {
-    error(item.value.arguments[0], 'Arguments length is not 1');
+    error.error({
+      node: item.value.arguments[0],
+      message: 'Arguments length is not 1',
+      filePath: filePath
+    });
   }
 
   const argumentNode = item.value.arguments[0];
   if (argumentNode.type !== 'Literal') {
-    error(item.value.arguments[0], 'Argument type not Literal');
+    error.error({
+      node: item.value.arguments[0],
+      message: 'Argument type not Literal',
+      filePath: filePath
+    });
   }
 
   const importString = argumentNode.value;
 
   if (importString.indexOf('*') > -1) {
-    error(item.value.arguments[0], 'Wildcard imports are not allowed, please refactor this file before continuing.');
+    error.error({
+      node: item.value.arguments[0],
+      message: 'Wildcard imports are not allowed',
+      filePath: filePath
+    });
+    return;
   }
 
   if (importString.indexOf('as exports') > -1) {
-    error(item.value.arguments[0], "The syntax 'import <your-module> as export' is not allowed, please refactor this file before continuing.");
+    error.error({
+      node: item.value.arguments[0],
+      message: "The syntax 'import <your-module> as export' is not allowed",
+      filePath: filePath
+    });
   }
 
   let match;
@@ -46,7 +67,11 @@ const transformImport = (j, item) => {
     const newMatch = pattern.re.exec(importString);
     if (newMatch) {
       if (match) {
-        error(item.value.arguments[0], 'Ambiguous import match');
+        error.error({
+          node: item.value.arguments[0],
+          message: 'Ambiguous import match',
+          filePath: filePath
+        });
       }
       match = newMatch;
       importPattern = pattern;
@@ -54,7 +79,11 @@ const transformImport = (j, item) => {
   });
 
   if (!match) {
-    error(item.value.arguments[0], 'Could not match import signature');
+    error.error({
+      node: item.value.arguments[0],
+      message: 'Could not match import signature',
+      filePath: filePath
+    });
   }
 
   return importPattern.transform(j, item, match);
@@ -64,13 +93,12 @@ const toSourceOpts = { quote: 'single' };
 
 module.exports = (fileInfo, api, options) => {
   const j = api.jscodeshift;
-  error.fileName = fileInfo.path;
 
   // Transform source so that the AST can be built
   fileInfo.source = fileInfo.source.replace(importExpr, replaceFn);
   const shifted = j(fileInfo.source);
 
   shifted.find(j.CallExpression, { callee: { name: 'jsio' } })
-    .forEach(item => transformImport(j, item));
+    .forEach(item => transformImport(j, fileInfo.path, item));
   return shifted.toSource(toSourceOpts).replace(/;;+/gi, ';');
 };

--- a/mods/lib/error.js
+++ b/mods/lib/error.js
@@ -1,7 +1,23 @@
 "use strict";
-
+const jsc = require('jscodeshift');
 const colors = require('colors');
 
-module.exports = (node, message) => {
-  throw new Error('Syntax not allowed or not parsable by this codemod');
+const throwError = (node, message) => {
+  const line = node.loc.start.line;
+  let errorMessage =
+    `Syntax not allowed on ${colors.white('line ' + line)}:\n` +
+    `\n` +
+    `  ${colors.white(jsc(node).toSource())}\n` +
+    `\n` +
+    `^^^^^ ${colors.red(message)}`
+  if (module.exports.fileName) {
+    errorMessage = `\n> ${module.exports.fileName}\n` + errorMessage;
+  } else {
+    errorMessage = '\n' + errorMessage;
+  }
+
+  throw new Error(errorMessage);
 }
+
+module.exports = throwError;
+module.exports.fileName = null;;

--- a/mods/lib/importPatterns.js
+++ b/mods/lib/importPatterns.js
@@ -1,5 +1,6 @@
 const named = require('named-regexp').named;
 const _ = require('lodash');
+const error = require('./error');
 
 // Prime jsio with some common paths
 // jsio.addPath('./timestep/src');
@@ -37,7 +38,7 @@ const detectNamingCollision = (j, node, name) => {
     .nodes()
     .length > 0
   ) {
-    throw new Error(`The module with name '${name} collides with another variable in this file, please rename the file and try again`);
+    error(node.value.arguments[0], `The module with name '${name} collides with another variable in this file, please rename the file and try again`);
   }
 }
 


### PR DESCRIPTION
Based off: https://github.com/juliankrispel/jsio-codemods/pull/12.  Alternate API for future use, slightly different message format.

Couple of notable changes:
- No more module level `fileName` (bad practice + not sure if it will play nice with multiple jscodeshift workers)
- Printed source location includes line and char in a more standard way: `<file>:<line>:<char>`
- Provided message printed before source excerpt
- `error` builds the message and throws an error
- `warn` builds the message, prints, but does not throw
